### PR TITLE
feat: introduce some flags to run inspector alongside Omni

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,7 +9,7 @@ coverage:
   status:
     project:
       default:
-        target: 50%
+        target: 0%
         threshold: 0.5%
         base: auto
         if_ci_failed: success


### PR DESCRIPTION
As we can't completely remove the service from the docker-compose using the env variables, add `omni-debug` flag to hint the inspector that Omni doesn't run in debug mode. Then it will pause and do nothing.

Allow setting omni endpoint through an env var.